### PR TITLE
Output a single "Universal" format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Transactions can consist of one or more operations:
 * A "trade" transaction has three operations (base asset, quote asset, and trading fee).
 
 This script organizes NovaDAX CSV operations into transactions, and outputs
-two Koinly CSVs (one for trades and another for all non-trades).
+a CSV in the [Koinly Universal Format][].
 
 ### Base and Quote assets
 
@@ -64,3 +64,4 @@ based on the fee's currency and the trade type (purchase or sale).
 [codacy_badge]: https://app.codacy.com/project/badge/Grade/e26d4581b014425fba78028573b15f98
 [codacy_coverage_badge]: https://app.codacy.com/project/badge/Coverage/e26d4581b014425fba78028573b15f98
 [codacy_project_url]: https://app.codacy.com/gh/thiagoalessio/nd2k/dashboard
+[Koinly Universal Format]: https://support.koinly.io/en/articles/9489976-how-to-create-a-custom-csv-file-with-your-data#3-universal-format

--- a/nd2k/types.py
+++ b/nd2k/types.py
@@ -1,8 +1,9 @@
+from abc import ABC, abstractmethod
 from enum import Enum
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, cast
 
 
 class OperationType(Enum):
@@ -27,13 +28,20 @@ class Operation:
 	status:  str
 
 
-class Transaction:
-	pass
+class Transaction(ABC):
+	@property
+	@abstractmethod
+	def date(self) -> datetime:
+		pass
 
 
 @dataclass
 class NonTrade(Transaction): # a.k.a. "Simple Transaction"
 	operation: Operation
+
+	@property
+	def date(self) -> datetime:
+		return self.operation.date
 
 
 class TradingPair(NamedTuple):
@@ -53,3 +61,7 @@ class Trade(Transaction):
 	summary:      str
 	operations:   TradeOperations
 	trading_pair: TradingPair
+
+	@property
+	def date(self) -> datetime:
+		return cast(Operation, self.operations.base_asset).date

--- a/tests/functional/novadax_to_koinly.feature
+++ b/tests/functional/novadax_to_koinly.feature
@@ -19,24 +19,21 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 			| 23/09/2024 20:01:41 | Depósito em Reais             | BRL      | R$ +50,000,00                       | Falha   |
 			| 23/09/2024 20:01:41 | Depósito em Reais             | BRL      | R$ +40,000,00                       | Sucesso |
 			| 28/09/2024 07:08:35 | Taxa de transação             | TIP      | -863,3841 TIP(≈R$0.22)              | Sucesso |
-			| 24/10/2024 16:19:22 | Taxa de saque de criptomoedas | DCR      | -0,01 DCR(≈R$0.69)                  | Sucesso |
+			| 24/10/2024 16:19:23 | Taxa de saque de criptomoedas | DCR      | -0,01 DCR(≈R$0.69)                  | Sucesso |
 			| 28/09/2024 07:08:35 | Compra(TIP/BRL)               | TIP      | +200,787,00 TIP(≈R$51.02)           | Sucesso |
 			| 24/10/2024 16:19:22 | Saque de criptomoedas         | DCR      | -1,54256146 DCR(≈R$106.55)          | Sucesso |
 			| 28/09/2024 07:08:35 | Compra(TIP/BRL)               | BRL      | R$ -51,01                           | Sucesso |
 
 		When the file is processed
 
-		Then a Koinly trades file should be created with the following transactions:
-			| date                | pair         | side |    amount |  total | fee_amount | fee_currency | orderid | tradeid |
-			| 2024-09-28 17:18:43 | MEMERUNE/BRL | BUY  |    362.77 | 155.04 |   1.559911 | MEMERUNE     |         |         |
-			| 2024-09-28 17:19:53 | MEMERUNE/BRL | SELL |    205.19 |  89.48 |   0.39     | BRL          |         |         |
-			| 2024-09-28 07:08:35 | TIP/BRL      | BUY  | 200787.00 |  51.01 | 863.3841   | TIP          |         |         |
-
-		And a Koinly non_trades file should be created with the following transactions:
-			| date                |           amount | symbol   | tag      | txhash |
-			| 2024-11-19 12:25:50 |    8900.00       | BRL      | withdraw |        |
-			| 2024-09-23 20:13:47 |       5.00       | BRL      | reward   |        |
-			| 2024-10-27 12:29:24 | 1609546.768462   | PUNKAI   | deposit  |        |
-			| 2024-09-23 20:01:41 |   40000.00       | BRL      | deposit  |        |
-			| 2024-10-24 16:19:22 |       0.01       | DCR      | fee      |        |
-			| 2024-10-24 16:19:22 |       1.54256146 | DCR      | withdraw |        |
+		Then a Koinly universal file should be created with the following transactions:
+			| date                | sent_amount   | sent_cur | recv_amount    | recv_cur | fee_amount | fee_cur  | nwa | nwc | label    | desc | txh |
+			| 2024-09-23 20:01:41 |               |          |   40000.00     | BRL      |            |          |     |     | deposit  |      |     |
+			| 2024-09-23 20:13:47 |               |          |       5.00     | BRL      |            |          |     |     | reward   |      |     |
+			| 2024-09-28 07:08:35 |   51.01       | BRL      |  200787.00     | TIP      | 863.3841   | TIP      |     |     | trade    |      |     |
+			| 2024-09-28 17:18:43 |  155.04       | BRL      |     362.77     | MEMERUNE |   1.559911 | MEMERUNE |     |     | trade    |      |     |
+			| 2024-09-28 17:19:53 |  205.19       | MEMERUNE |      89.48     | BRL      |   0.39     | BRL      |     |     | trade    |      |     |
+			| 2024-10-24 16:19:22 |    1.54256146 | DCR      |                |          |            |          |     |     | withdraw |      |     |
+			| 2024-10-24 16:19:23 |    0.01       | DCR      |                |          |            |          |     |     | fee      |      |     |
+			| 2024-10-27 12:29:24 |               |          | 1609546.768462 | PUNKAI   |            |          |     |     | deposit  |      |     |
+			| 2024-11-19 12:25:50 | 8900.00       | BRL      |                |          |            |          |     |     | withdraw |      |     |


### PR DESCRIPTION
It isn't possible to correctly import "withdraw fee" transactions using the previous (trades & non-trades) file formats.
(See issue #11)