### PR TITLE
Combine transactions with same timestamp+summary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: test coverage lint type-checker complexity-metrics security-scan
+all: test coverage-html lint type-checker complexity-metrics security-scan
 
 clean:
 	rm -rf build dist nd2k.egg-info

--- a/nd2k/queries.py
+++ b/nd2k/queries.py
@@ -1,4 +1,4 @@
-from .types import Operation, Trade, TradeOperations
+from .types import Operation, Trade, TradeOperations, Transaction
 
 
 def is_successful(op: Operation) -> bool:
@@ -65,3 +65,7 @@ def get_any_asset(ops: TradeOperations) -> Operation:
 	if any_asset:
 		return any_asset
 	raise ValueError("Empty Trade")
+
+
+def is_trade(t: Transaction) -> bool:
+	return isinstance(t, Trade)

--- a/nd2k/utils.py
+++ b/nd2k/utils.py
@@ -3,6 +3,8 @@ import unicodedata
 
 from datetime import datetime
 from decimal import Decimal
+from functools import reduce
+from typing import Any, Callable, cast
 from . import queries as q
 from nd2k.types import (
 	Operation,
@@ -10,6 +12,8 @@ from nd2k.types import (
 	Trade,
 	TradeOperations,
 	TradingPair,
+	Transaction,
+	NonTrade,
 )
 
 
@@ -91,3 +95,16 @@ def create_trade(op: Operation) -> Trade:
 	tr.operations.base_asset  = op if q.fits_as_base_asset(op, tr)  else None
 	tr.operations.quote_asset = op if q.fits_as_quote_asset(op, tr) else None
 	return tr
+
+
+def pipe(data: Any, *funcs: Callable[..., Any]) -> Any:
+	return reduce(lambda x, f: f(x), funcs, data)
+
+
+def combine_group_index(t: Transaction) -> str:
+	idx = str(t.date)
+	if q.is_trade(t):
+		idx += cast(Trade, t).summary
+	else:
+		idx += cast(NonTrade, t).operation.summary
+	return idx

--- a/tests/functional/novadax_to_koinly.feature
+++ b/tests/functional/novadax_to_koinly.feature
@@ -8,6 +8,10 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 			| date                | summary                       | symbol   | amount                              | status  |
 			| 19/11/2024 12:25:50 | Saque em Reais                | BRL      | R$ -8,900,00                        | Sucesso |
 			| 23/09/2024 20:13:47 | Redeemed Bonus                | BRL      | R$ +5,00                            | Sucesso |
+			| 23/09/2024 20:13:47 | Redeemed Bonus                | BRL      | R$ +5,00                            | Sucesso |
+			| 28/09/2024 17:18:43 | Taxa de transação             | MEMERUNE | -4,00 MEMERUNE(≈R$0.67)             | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | BRL      | R$ -100,00                          | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | MEMERUNE | +400,00 MEMERUNE(≈R$155.05)         | Sucesso |
 			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | MEMERUNE | +362,77 MEMERUNE(≈R$155.05)         | Sucesso |
 			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)           | BRL      | R$ +89,48                           | Sucesso |
 			| 27/10/2024 12:29:24 | Depósito de criptomoedas      | PUNKAI   | +1,609,546,768462 PUNKAI(≈R$160.95) | Sucesso |
@@ -29,9 +33,9 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 		Then a Koinly universal file should be created with the following transactions:
 			| date                | sent_amount   | sent_cur | recv_amount    | recv_cur | fee_amount | fee_cur  | nwa | nwc | label    | desc | txh |
 			| 2024-09-23 20:01:41 |               |          |   40000.00     | BRL      |            |          |     |     | deposit  |      |     |
-			| 2024-09-23 20:13:47 |               |          |       5.00     | BRL      |            |          |     |     | reward   |      |     |
+			| 2024-09-23 20:13:47 |               |          |      10.00     | BRL      |            |          |     |     | reward   |      |     |
 			| 2024-09-28 07:08:35 |   51.01       | BRL      |  200787.00     | TIP      | 863.3841   | TIP      |     |     | trade    |      |     |
-			| 2024-09-28 17:18:43 |  155.04       | BRL      |     362.77     | MEMERUNE |   1.559911 | MEMERUNE |     |     | trade    |      |     |
+			| 2024-09-28 17:18:43 |  255.04       | BRL      |     762.77     | MEMERUNE |   5.559911 | MEMERUNE |     |     | trade    |      |     |
 			| 2024-09-28 17:19:53 |  205.19       | MEMERUNE |      89.48     | BRL      |   0.39     | BRL      |     |     | trade    |      |     |
 			| 2024-10-24 16:19:22 |    1.54256146 | DCR      |                |          |            |          |     |     | withdraw |      |     |
 			| 2024-10-24 16:19:23 |    0.01       | DCR      |                |          |            |          |     |     | fee      |      |     |


### PR DESCRIPTION
Koinly considers similar transactions with the same timestamp as duplicates, when they shouldn't be discarded, since they might be an order being partially fulfilled, or a trading bot placing orders in an automated manner.

Issue #12 