### PR TITLE
Aggregate Transactions by Operation + Pair

### DIFF
--- a/nd2k/converter/__init__.py
+++ b/nd2k/converter/__init__.py
@@ -1,5 +1,5 @@
 from .combine_groups import combine_groups
-from .group_similar import group_similar_by_timestamp
+from .group_similar import group_similar_by_summary
 from .organize_rows import organize_rows
 
-__all__ = ["combine_groups", "group_similar_by_timestamp", "organize_rows"]
+__all__ = ["combine_groups", "group_similar_by_summary", "organize_rows"]

--- a/nd2k/converter/group_similar.py
+++ b/nd2k/converter/group_similar.py
@@ -5,9 +5,9 @@ from ..queries import is_trade
 from ..types import Transaction, TransactionGroups, Trade, NonTrade
 
 
-def group_similar_by_timestamp(lst: list[Transaction]) -> TransactionGroups:
+def group_similar_by_summary(lst: list[Transaction]) -> TransactionGroups:
 	"""
-	Group transactions that have the same timestamp+summary
+	Group transactions that have the same summary
 	"""
 	groups: TransactionGroups = defaultdict(list)
 	for t in lst:
@@ -17,9 +17,8 @@ def group_similar_by_timestamp(lst: list[Transaction]) -> TransactionGroups:
 
 
 def get_group_index(t: Transaction) -> str:
-	idx = str(t.date)
 	if is_trade(t):
-		idx += cast(Trade, t).summary
+		return cast(Trade, t).summary
 	else:
-		idx += cast(NonTrade, t).operation.summary
-	return idx
+		t = cast(NonTrade, t)
+		return f"{t.operation.summary}+{t.operation.symbol}"

--- a/nd2k/converter/organize_rows.py
+++ b/nd2k/converter/organize_rows.py
@@ -74,7 +74,7 @@ def create_or_update_trade(op: Operation, lst: list[PartialTrade]) -> PartialTra
 def organize_rows_failed(lst: list[PartialTrade]) -> None:
 	"""
 	If by the end of "organize_rows" we still have partial trades,
-	something is wrong and the program shouldn't proceed.
+	report the errors, but proceed with the Koinly CSV generation.
 	"""
 	error_msg = "Error! The script went through all rows in the NovaDAX CSV "
 	error_msg+= "and could not complete the following trades:\n\n"
@@ -84,8 +84,8 @@ def organize_rows_failed(lst: list[PartialTrade]) -> None:
 	error_msg+= "If you are sure the input file is correct, please open an "
 	error_msg+= "issue at https://github.com/thiagoalessio/nd2k/issues/new "
 	error_msg+= "and attach the file that caused this error.\n"
+	error_msg+= "The transactions above were excluded from the final report."
 	print(error_msg)
-	exit(1)
 
 
 def create_operation(csv_line: list[str]) -> Operation:

--- a/nd2k/main.py
+++ b/nd2k/main.py
@@ -17,7 +17,7 @@ def main() -> None:
 
 	csv_rows     = read(input_file)
 	transactions = converter.organize_rows(csv_rows)
-	grouped      = converter.group_similar_by_timestamp(transactions)
+	grouped      = converter.group_similar_by_summary(transactions)
 	combined     = converter.combine_groups(grouped)
 	ordered      = utils.order_by_date(combined)
 	formatted    = formatter.universal(ordered)

--- a/tests/functional/novadax_to_koinly.feature
+++ b/tests/functional/novadax_to_koinly.feature
@@ -6,8 +6,12 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 	Scenario: Convert NovaDAX operations to Koinly transactions
 		Given a NovaDAX CSV file has the following operations:
 			| date                | summary                       | symbol   | amount                              | status  |
+			| 28/09/2024 17:18:43 | Taxa de transação             | MEMERUNE | -10,00 MEMERUNE(≈R$0.67)            | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | BRL      | R$ -54,00                           | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | MEMERUNE | +250,00 MEMERUNE(≈R$155.05)         | Sucesso |
 			| 19/11/2024 12:25:50 | Saque em Reais                | BRL      | R$ -8,900,00                        | Sucesso |
 			| 23/09/2024 20:13:47 | Redeemed Bonus                | BRL      | R$ +5,00                            | Sucesso |
+			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)           | BRL      | R$ +89,48                           | Sucesso |
 			| 23/09/2024 20:13:47 | Redeemed Bonus                | BRL      | R$ +5,00                            | Sucesso |
 			| 28/09/2024 17:18:43 | Taxa de transação             | MEMERUNE | -4,00 MEMERUNE(≈R$0.67)             | Sucesso |
 			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | BRL      | R$ -100,00                          | Sucesso |
@@ -16,7 +20,9 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)           | BRL      | R$ +89,48                           | Sucesso |
 			| 27/10/2024 12:29:24 | Depósito de criptomoedas      | PUNKAI   | +1,609,546,768462 PUNKAI(≈R$160.95) | Sucesso |
 			| 28/09/2024 17:19:54 | Taxa de transação             | BRL      | R$ -0,39                            | Sucesso |
+			| 28/09/2024 17:19:54 | Taxa de transação             | BRL      | R$ -0,39                            | Sucesso |
 			| 28/09/2024 17:19:53 | Taxa de transação             | BRL      | R$ -0,39                            | Falha   |
+			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)           | MEMERUNE | -205,19 MEMERUNE(≈R$87.58)          | Sucesso |
 			| 28/09/2024 17:18:43 | Taxa de transação             | MEMERUNE | -1,559911 MEMERUNE(≈R$0.67)         | Sucesso |
 			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)           | MEMERUNE | -205,19 MEMERUNE(≈R$87.58)          | Sucesso |
 			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)          | BRL      | R$ -155,04                          | Sucesso |
@@ -25,6 +31,7 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 			| 28/09/2024 07:08:35 | Taxa de transação             | TIP      | -863,3841 TIP(≈R$0.22)              | Sucesso |
 			| 24/10/2024 16:19:23 | Taxa de saque de criptomoedas | DCR      | -0,01 DCR(≈R$0.69)                  | Sucesso |
 			| 28/09/2024 07:08:35 | Compra(TIP/BRL)               | TIP      | +200,787,00 TIP(≈R$51.02)           | Sucesso |
+			| 24/10/2024 16:19:22 | Saque de criptomoedas         | DOGE     | -1234,56 DOGE(≈R$11.22)             | Sucesso |
 			| 24/10/2024 16:19:22 | Saque de criptomoedas         | DCR      | -1,54256146 DCR(≈R$106.55)          | Sucesso |
 			| 28/09/2024 07:08:35 | Compra(TIP/BRL)               | BRL      | R$ -51,01                           | Sucesso |
 
@@ -35,9 +42,10 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 			| 2024-09-23 20:01:41 |               |          |   40000.00     | BRL      |            |          |     |     | deposit  | Depósito em Reais             |     |
 			| 2024-09-23 20:13:47 |               |          |      10.00     | BRL      |            |          |     |     | reward   | Redeemed Bonus                |     |
 			| 2024-09-28 07:08:35 |   51.01       | BRL      |  200787.00     | TIP      | 863.3841   | TIP      |     |     | trade    | Compra(TIP/BRL)               |     |
-			| 2024-09-28 17:18:43 |  255.04       | BRL      |     762.77     | MEMERUNE |   5.559911 | MEMERUNE |     |     | trade    | Compra(MEMERUNE/BRL)          |     |
-			| 2024-09-28 17:19:53 |  205.19       | MEMERUNE |      89.48     | BRL      |   0.39     | BRL      |     |     | trade    | Venda(MEMERUNE/BRL)           |     |
+			| 2024-09-28 17:18:43 |  309.04       | BRL      |    1012.77     | MEMERUNE |  15.559911 | MEMERUNE |     |     | trade    | Compra(MEMERUNE/BRL)          |     |
+			| 2024-09-28 17:19:53 |  410.38       | MEMERUNE |     178.96     | BRL      |   0.78     | BRL      |     |     | trade    | Venda(MEMERUNE/BRL)           |     |
 			| 2024-10-24 16:19:22 |    1.54256146 | DCR      |                |          |            |          |     |     | withdraw | Saque de criptomoedas         |     |
+			| 2024-10-24 16:19:22 | 1234.56       | DOGE     |                |          |            |          |     |     | withdraw | Saque de criptomoedas         |     |
 			| 2024-10-24 16:19:23 |    0.01       | DCR      |                |          |            |          |     |     | fee      | Taxa de saque de criptomoedas |     |
 			| 2024-10-27 12:29:24 |               |          | 1609546.768462 | PUNKAI   |            |          |     |     | deposit  | Depósito de criptomoedas      |     |
 			| 2024-11-19 12:25:50 | 8900.00       | BRL      |                |          |            |          |     |     | withdraw | Saque em Reais                |     |
@@ -45,22 +53,39 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 
 	Scenario: NovaDAX file is incomplete
 		Given a NovaDAX CSV file has the following operations:
-			| date                | summary              | symbol   | amount                      | status  |
-			| 28/09/2024 17:18:43 | Taxa de transação    | MEMERUNE | -4,00 MEMERUNE(≈R$0.67)     | Sucesso |
-			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL) | BRL      | R$ -100,00                  | Sucesso |
-			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL) | MEMERUNE | +362,77 MEMERUNE(≈R$155.05) | Sucesso |
-			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)  | BRL      | R$ +89,48                   | Sucesso |
-			| 28/09/2024 17:19:54 | Taxa de transação    | BRL      | R$ -0,39                    | Sucesso |
-			| 28/09/2024 17:18:43 | Taxa de transação    | MEMERUNE | -1,559911 MEMERUNE(≈R$0.67) | Sucesso |
-			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)  | MEMERUNE | -205,19 MEMERUNE(≈R$87.58)  | Sucesso |
-			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL) | BRL      | R$ -155,04                  | Sucesso |
-			| 28/09/2024 07:08:35 | Taxa de transação    | TIP      | -863,3841 TIP(≈R$0.22)      | Sucesso |
-			| 28/09/2024 07:08:35 | Compra(TIP/BRL)      | TIP      | +200,787,00 TIP(≈R$51.02)   | Sucesso |
-			| 28/09/2024 07:08:35 | Compra(TIP/BRL)      | BRL      | R$ -51,01                   | Sucesso |
+			| date                | summary               | symbol   | amount                      | status  |
+			| 28/09/2024 17:18:43 | Taxa de transação     | MEMERUNE | -4,00 MEMERUNE(≈R$0.67)     | Sucesso |
+			| 23/09/2024 20:13:47 | Redeemed Bonus        | BRL      | R$ +5,00                    | Sucesso |
+			| 23/09/2024 20:13:47 | Redeemed Bonus        | BRL      | R$ +5,00                    | Sucesso |
+			| 23/09/2024 20:13:47 | Redeemed Bonus        | BRL      | R$ +5,00                    | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)  | BRL      | R$ -100,00                  | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)  | MEMERUNE | +362,77 MEMERUNE(≈R$155.05) | Sucesso |
+			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)   | BRL      | R$ +89,48                   | Sucesso |
+			| 23/09/2024 20:01:41 | Depósito em Reais     | BRL      | R$ +50,000,00               | Sucesso |
+			| 28/09/2024 17:19:54 | Taxa de transação     | BRL      | R$ -0,39                    | Sucesso |
+			| 28/09/2024 17:18:43 | Taxa de transação     | MEMERUNE | -1,559911 MEMERUNE(≈R$0.67) | Sucesso |
+			| 28/09/2024 17:19:53 | Venda(MEMERUNE/BRL)   | MEMERUNE | -205,19 MEMERUNE(≈R$87.58)  | Sucesso |
+			| 28/09/2024 17:18:43 | Compra(MEMERUNE/BRL)  | BRL      | R$ -155,04                  | Sucesso |
+			| 23/09/2024 20:01:41 | Depósito em Reais     | BRL      | R$ +40,000,00               | Sucesso |
+			| 28/09/2024 07:08:35 | Taxa de transação     | TIP      | -863,3841 TIP(≈R$0.22)      | Sucesso |
+			| 28/09/2024 07:08:35 | Compra(TIP/BRL)       | TIP      | +200,787,00 TIP(≈R$51.02)   | Sucesso |
+			| 24/10/2024 16:19:22 | Saque de criptomoedas | DOGE     | -1234,56 DOGE(≈R$11.22)     | Sucesso |
+			| 24/10/2024 16:19:22 | Saque de criptomoedas | DCR      | -1,54256146 DCR(≈R$106.55)  | Sucesso |
+			| 28/09/2024 07:08:35 | Compra(TIP/BRL)       | BRL      | R$ -51,01                   | Sucesso |
 
 		When I attempt to process the file
 
-		Then the following error should appear:
+		Then a Koinly universal file should be created with the following transactions:
+			| date                | sent_amount   | sent_cur | recv_amount    | recv_cur | fee_amount | fee_cur  | nwa | nwc | label    | description           | txh |
+			| 2024-09-23 20:01:41 |               |          |   90000.00     | BRL      |            |          |     |     | deposit  | Depósito em Reais     |     |
+			| 2024-09-23 20:13:47 |               |          |      15.00     | BRL      |            |          |     |     | reward   | Redeemed Bonus        |     |
+			| 2024-09-28 07:08:35 |   51.01       | BRL      |  200787.00     | TIP      | 863.3841   | TIP      |     |     | trade    | Compra(TIP/BRL)       |     |
+			| 2024-09-28 17:18:43 |  155.04       | BRL      |     362.77     | MEMERUNE |   1.559911 | MEMERUNE |     |     | trade    | Compra(MEMERUNE/BRL)  |     |
+			| 2024-09-28 17:19:53 |  205.19       | MEMERUNE |      89.48     | BRL      |   0.39     | BRL      |     |     | trade    | Venda(MEMERUNE/BRL)   |     |
+			| 2024-10-24 16:19:22 |    1.54256146 | DCR      |                |          |            |          |     |     | withdraw | Saque de criptomoedas |     |
+			| 2024-10-24 16:19:22 | 1234.56       | DOGE     |                |          |            |          |     |     | withdraw | Saque de criptomoedas |     |
+
+		But the following error should appear:
 			"""
 			Error! The script went through all rows in the NovaDAX CSV and could not complete the following trades:
 
@@ -70,4 +95,5 @@ Feature: Convert NovaDAX CSV to Koinly-compatible transactions
 
 			The input file may be faulty, or the script misinterpreted its contents.
 			If you are sure the input file is correct, please open an issue at https://github.com/thiagoalessio/nd2k/issues/new and attach the file that caused this error.
+			The transactions above were excluded from the final report.
 			"""

--- a/tests/functional/test_novadax_to_koinly.py
+++ b/tests/functional/test_novadax_to_koinly.py
@@ -1,5 +1,4 @@
 import csv
-import pytest
 
 from pathlib import Path
 from typing import Any
@@ -32,9 +31,7 @@ def invoke_nd2k_tool(tmp_path: Path, monkeypatch: Any) -> None:
 def invoke_nd2k_tool_with_bad_file(tmp_path: Path, capsys: Any, monkeypatch: Any) -> str:
 	file = tmp_path / "temp.csv"
 	monkeypatch.setattr("sys.argv", ["nd2k", str(file)])
-	with pytest.raises(SystemExit) as exc_info:
-		main()
-	assert exc_info.value.code == 1
+	main()
 	return str(capsys.readouterr().out)
 
 


### PR DESCRIPTION
Regardless of timestamp, just combine everything.
Proceed with the creation of Koinly report even with incomplete trades.